### PR TITLE
Error when import skimage.io

### DIFF
--- a/create_mnistm.py
+++ b/create_mnistm.py
@@ -8,6 +8,7 @@ import tarfile
 import os
 import numpy as np
 import skimage
+import skimage.io
 import urllib.request
 import tensorflow as tf
 import h5py


### PR DESCRIPTION
When running the create_mnistm.py, backgrounds are not extracted properly. Building dataset thus fails due to skimage.io package not being loaded.

https://stackoverflow.com/questions/32876962/python-module-import-why-are-components-only-available-when-explicitly-importe